### PR TITLE
fix wrong default description

### DIFF
--- a/src/hooks/CountdownContext.tsx
+++ b/src/hooks/CountdownContext.tsx
@@ -35,7 +35,7 @@ export const CountdownProvider: React.FC<{ children: React.ReactNode }> = ({
   const defaultDate = new Date(
     `${new Date().getFullYear() + 1}-01-01T00:00:00.000Z`
   );
-  const defaultDescription = (defaultDate.getFullYear() + 1).toString();
+  const defaultDescription = (new Date().getFullYear() + 1).toString();
   const defaultTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   const defaultStyle = "fractional";
   const defaultBackground = BackgroundOptions[0];


### PR DESCRIPTION
Using `defaultDate` caused anyone in UTC+0 or above to see 2026 as the default description, while it should be 2025 instead. This fix has been tested for both negative and positive UTC timezones as well as UTC+0